### PR TITLE
Fix : Italic typo in main page+ text issue in payout page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CodeHawks is a **leading competitive smart contract audit marketplace powered by
 
 Digital value exchange enabled by decentralized finance and smart contracts requires outstanding security and best practices to reach mainstream adoption.&#x20;
 
-O_ver $250B is locked in the DeFi ecosystem, and in the past six months alone, over $1B has been lost in more than 100 DeFi exploits._ \
+_Over $250B is locked in the DeFi ecosystem, and in the past six months alone, over $1B has been lost in more than 100 DeFi exploits._ \
 \
 Last year, 6% of the Total Value Locked (TVL) in DeFi was stolen, resulting in the loss of hundreds of millions of dollars in users and protocols funds and, inherently, faith in the entire ecosystem.
 

--- a/hawks-auditors/payouts.md
+++ b/hawks-auditors/payouts.md
@@ -88,6 +88,6 @@ These have the same **root cause** even though they are submitted with different
 The following are not considered duplicates:
 
 * **Users can lose precision when it doesn't check for address(0): low.**
-* **Multiply before divide loses precision: low.**
+* **Dividing before multiplying loses precision: low.**
 
 Since they have different root causes (checking the zero address vs dividing before multiplying), they are not considered duplicates.


### PR DESCRIPTION
Fixed the beginning of the italic part in the main page.

Fixed text error in payout -> Duplicate issues